### PR TITLE
SAK-82 fixed issue where debug enabled breaks form submission

### DIFF
--- a/services/src/main/java/org/sakaiproject/kaltura/services/KalturaLTIService.java
+++ b/services/src/main/java/org/sakaiproject/kaltura/services/KalturaLTIService.java
@@ -848,22 +848,20 @@ public class KalturaLTIService {
 					text.append("\n-->\n");
 				}
 			}
-		} else {
-			// paint auto submit script
-			text
-				.append(" <script language=\"javascript\"> \n"
-						+ "	document.getElementById(\"ltiLaunchFormSubmitArea\").style.display = \"none\";\n"
-						+ "	nei = document.createElement('input');\n"
-						+ "	nei.setAttribute('type', 'hidden');\n"
-						+ "	nei.setAttribute('name', '"
-						+ BasicLTIUtil.BASICLTI_SUBMIT
-						+ "');\n"
-						+ "	nei.setAttribute('value', '"
-						+ newMap.get(BasicLTIUtil.BASICLTI_SUBMIT)
-						+ "');\n"
-						+ "	document.getElementById(\"ltiLaunchForm\").appendChild(nei);\n"
-						+ "</script>");
+
 		}
+		text.append(" <script language=\"javascript\"> \n"
+					+ "	document.getElementById(\"ltiLaunchFormSubmitArea\").style.display = \"none\";\n"
+					+ "	nei = document.createElement('input');\n"
+					+ "	nei.setAttribute('type', 'hidden');\n"
+					+ "	nei.setAttribute('name', '"
+					+ BasicLTIUtil.BASICLTI_SUBMIT
+					+ "');\n"
+					+ "	nei.setAttribute('value', '"
+					+ newMap.get(BasicLTIUtil.BASICLTI_SUBMIT)
+					+ "');\n"
+					+ "	document.getElementById(\"ltiLaunchForm\").appendChild(nei);\n"
+					+ "</script>");
 
 		String htmltext = text.toString();
 		return htmltext;


### PR DESCRIPTION
If a module has debug enabled in sakai.properties (i.e. kaltura.<module-name>.debug=on, when the form is submitted, a needed property is not sent or transmitted.  This fix will always send that property, even if debug is enabled.
