### PR TITLE
SAK-132 CKEditor fails to load if it's in a forum embedded in a lesson

### DIFF
--- a/ckeditor/kaltura/plugin.js
+++ b/ckeditor/kaltura/plugin.js
@@ -13,9 +13,17 @@ var ckeditorId;
                 ckeditorId = editor.name;
                 var height = 480;
                 var width = 770;
+                var siteId = "";
+                if (typeof(parent.portal) != "undefined") {
+                    siteId = parent.portal.siteId;
+                }
+                else if (typeof(parent.parent.portal) != "undefined") {
+                    siteId = parent.parent.portal.siteId;
+                }
+
                 CKEDITOR.dialog.addIframe(pluginName,
                     'Kaltura',
-                    '/media-gallery-tool/ckeditor.htm?siteid=' + parent.portal.siteId,
+                    '/media-gallery-tool/ckeditor.htm?siteid=' + siteId,
                     width,
                     height,
                     function() {


### PR DESCRIPTION
It seems like it embeds it in a frame within a frame.

This logic probably could loop through a couple more parents looking for the portal variable but I don't think there would be too many nested iframes, this is the first I'd seen of this come up.
